### PR TITLE
Implement Constraints, and add dal.ArrayType

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -20,6 +20,7 @@ type BackendFeature int
 const (
 	PartialSearch BackendFeature = iota
 	CompositeKeys
+	Constraints
 )
 
 type Backend interface {

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -393,6 +393,14 @@ func (self *RedisBackend) decode(collection *dal.Collection, key string, value [
 			} else {
 				return nil, err
 			}
+		case dal.ArrayType:
+			var out []interface{}
+
+			if err := json.Unmarshal(value, &out); err == nil {
+				return out, nil
+			} else {
+				return nil, err
+			}
 		default:
 			var out interface{}
 

--- a/backends/sql-backend-mysql.go
+++ b/backends/sql-backend-mysql.go
@@ -96,9 +96,12 @@ func (self *SqlBackend) initializeMysql() (string, string, error) {
 								field.Type = dal.TimeType
 
 							} else {
-								if field.Length == objectFieldHintLength {
+								switch field.Length {
+								case SqlObjectFieldHintLength:
 									field.Type = dal.ObjectType
-								} else {
+								case SqlArrayFieldHintLength:
+									field.Type = dal.ArrayType
+								default:
 									field.Type = dal.RawType
 								}
 							}

--- a/backends/sql-backend-mysql.go
+++ b/backends/sql-backend-mysql.go
@@ -19,6 +19,8 @@ func (self *SqlBackend) initializeMysql() (string, string, error) {
 	self.listAllTablesQuery = `SHOW TABLES`
 	self.createPrimaryKeyIntFormat = `%s INT AUTO_INCREMENT NOT NULL`
 	self.createPrimaryKeyStrFormat = `%s VARCHAR(255) NOT NULL`
+	self.foreignKeyConstraintFormat = `FOREIGN KEY(%s) REFERENCES %s (%s) %s`
+	self.defaultCurrentTimeString = `CURRENT_TIMESTAMP`
 
 	// the bespoke method for determining table information for sqlite3
 	self.refreshCollectionFunc = func(datasetName string, collectionName string) (*dal.Collection, error) {

--- a/backends/sql-backend-postgres.go
+++ b/backends/sql-backend-postgres.go
@@ -145,9 +145,12 @@ func (self *SqlBackend) initializePostgres() (string, string, error) {
 								field.Type = dal.TimeType
 
 							} else {
-								if field.Length == objectFieldHintLength {
+								switch field.Length {
+								case SqlObjectFieldHintLength:
 									field.Type = dal.ObjectType
-								} else {
+								case SqlArrayFieldHintLength:
+									field.Type = dal.ArrayType
+								default:
 									field.Type = dal.RawType
 								}
 							}

--- a/backends/sql-backend-postgres.go
+++ b/backends/sql-backend-postgres.go
@@ -23,6 +23,9 @@ func (self *SqlBackend) initializePostgres() (string, string, error) {
 	self.createPrimaryKeyStrFormat = `%s VARCHAR(255)`
 	self.countEstimateQuery = "SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = to_regclass('%s')"
 	self.countExactQuery = "SELECT COUNT(*) AS exact FROM (SELECT 1 FROM %s LIMIT %d) t"
+	self.foreignKeyConstraintFormat = `FOREIGN KEY(%s) REFERENCES %s (%s) %s`
+	// self.defaultCurrentTimeString = `now() AT TIME ZONE 'utc'`
+	self.defaultCurrentTimeString = `CURRENT_TIMESTAMP`
 
 	// the bespoke method for determining table information for sqlite3
 	self.refreshCollectionFunc = func(datasetName string, collectionName string) (*dal.Collection, error) {

--- a/backends/sql-backend-sqlite.go
+++ b/backends/sql-backend-sqlite.go
@@ -111,12 +111,14 @@ func (self *SqlBackend) initializeSqlite() (string, string, error) {
 						field.Type = dal.FloatType
 
 					default:
-						if field.Length == objectFieldHintLength {
+						switch field.Length {
+						case SqlObjectFieldHintLength:
 							field.Type = dal.ObjectType
-						} else {
+						case SqlArrayFieldHintLength:
+							field.Type = dal.ArrayType
+						default:
 							field.Type = dal.RawType
 						}
-
 					}
 
 					if pk == 1 {

--- a/backends/sql.go
+++ b/backends/sql.go
@@ -937,6 +937,15 @@ func (self *SqlBackend) scanFnValueToRecord(queryGen *generators.Sql, collection
 							value = asBytes
 						}
 
+					case dal.ArrayType:
+						var destA []interface{}
+
+						if err := queryGen.ArrayTypeDecode(asBytes, &destA); err == nil {
+							value = destA
+						} else {
+							value = asBytes
+						}
+
 					default:
 						value = nil
 

--- a/dal/collection.go
+++ b/dal/collection.go
@@ -65,9 +65,14 @@ type Collection struct {
 
 	// Specifies how fields in this Collection relate to records from other collections.  This is
 	// a partial implementation of a relational model, specifically capturing one-to-one or
-	// one-to-many relationships.  The definitions here will retrieve the assocated records from
+	// one-to-many relationships.  The definitions here will retrieve the associated records from
 	// another, and those values will replace the value that is actually in this Collection's field.
 	EmbeddedCollections []Relationship `json:"embed,omitempty"`
+
+	// Allows for constraints to be applied to a collection.  In addition to informing Pivot about the
+	// relationships between collections, this data is also used to enforce referential integrity for
+	// backends that support such guarantees (e.g.: ACID-compliant RDBMS').
+	Constraints []Constraint `json:"constraints,omitempty"`
 
 	// Specifies which fields can be seen when records are from relationships defined on other
 	// Collections.  This can be used to restrict the exposure) of sensitive data in this Collection

--- a/dal/constraint.go
+++ b/dal/constraint.go
@@ -1,0 +1,36 @@
+package dal
+
+import "fmt"
+
+type Constraint struct {
+	// Represents the name (or array of names) of the local field the constraint is being applied to.
+	On interface{} `json:"on"`
+
+	// The remote collection the constraint applies to.
+	Collection string `json:"collection"`
+
+	// The remote field (or fields) in the remote collection the constraint applies to.
+	Field interface{} `json:"field"`
+
+	// Provides backend-specific additional options for the constraint.
+	Options string `json:"options,omitempty"`
+
+	// Whether to omit this constraint when determining embedded collections.
+	NoEmbed bool `json:"noembed,omitempty"`
+}
+
+func (self Constraint) Validate() error {
+	if self.On == `` {
+		return fmt.Errorf("invalid constraint missing local field")
+	}
+
+	if self.Collection == `` {
+		return fmt.Errorf("invalid constraint missing remote collection name")
+	}
+
+	if self.Field == `` {
+		return fmt.Errorf("invalid constraint missing remote field")
+	}
+
+	return nil
+}

--- a/dal/field_test.go
+++ b/dal/field_test.go
@@ -483,4 +483,63 @@ func TestFieldConvertValueObject(t *testing.T) {
 	}, value)
 }
 
-// func TestFieldConvertValueRaw(t *testing.T) {}
+func TestFieldConvertValueArray(t *testing.T) {
+	assert := require.New(t)
+	var field *Field
+	var value interface{}
+	var err error
+
+	field = &Field{
+		Type: ArrayType,
+	}
+
+	// not required, no default
+	// -------------------------------------------------------------------------
+	value, err = field.ConvertValue([]interface{}{})
+	assert.NoError(err)
+	assert.EqualValues(make([]interface{}, 0), value)
+
+	value, err = field.ConvertValue(nil)
+	assert.NoError(err)
+	assert.Nil(value)
+
+	value, err = field.ConvertValue([]interface{}{1, 2, 3})
+	assert.NoError(err)
+	assert.Equal([]interface{}{1, 2, 3}, value)
+
+	value, err = field.ConvertValue([]string{`1`, `2`, `3`})
+	assert.NoError(err)
+	assert.Equal([]interface{}{`1`, `2`, `3`}, value)
+
+	// required, no default
+	// -------------------------------------------------------------------------
+	field.Required = true
+
+	value, err = field.ConvertValue([]interface{}{})
+	assert.NoError(err)
+	assert.Equal(make([]interface{}, 0), value)
+
+	value, err = field.ConvertValue(nil)
+	assert.NoError(err)
+	assert.Equal(make([]interface{}, 0), value)
+
+	value, err = field.ConvertValue([]bool{true, true, false})
+	assert.NoError(err)
+	assert.Equal([]interface{}{true, true, false}, value)
+
+	// required, with default
+	// -------------------------------------------------------------------------
+	field.DefaultValue = []string{`a`, `b`, `c`}
+
+	value, err = field.ConvertValue(nil)
+	assert.NoError(err)
+	assert.Equal([]interface{}{`a`, `b`, `c`}, value)
+
+	value, err = field.ConvertValue(nil)
+	assert.NoError(err)
+	assert.Equal([]interface{}{`a`, `b`, `c`}, value)
+
+	value, err = field.ConvertValue([]int64{9, 8, 7})
+	assert.NoError(err)
+	assert.Equal([]interface{}{int64(9), int64(8), int64(7)}, value)
+}

--- a/dal/record.go
+++ b/dal/record.go
@@ -24,11 +24,18 @@ type Record struct {
 	Operation      string                 `json:"operation,omitempty"`
 }
 
-func NewRecord(id interface{}) *Record {
-	return &Record{
-		ID:     id,
-		Fields: make(map[string]interface{}),
+func NewRecord(id interface{}, data ...map[string]interface{}) *Record {
+	record := &Record{
+		ID: id,
 	}
+
+	if len(data) > 0 && len(data[0]) > 0 {
+		record.Fields = data[0]
+	} else {
+		record.Fields = make(map[string]interface{})
+	}
+
+	return record
 }
 
 func NewRecordErr(id interface{}, err error) *Record {

--- a/dal/relationship.go
+++ b/dal/relationship.go
@@ -6,3 +6,11 @@ type Relationship struct {
 	CollectionName string      `json:"collection,omitempty"`
 	Fields         []string    `json:"fields,omitempty"`
 }
+
+func (self *Relationship) RelatedCollectionName() string {
+	if self.Collection != nil {
+		return self.Collection.Name
+	} else {
+		return self.CollectionName
+	}
+}

--- a/dal/types.go
+++ b/dal/types.go
@@ -16,6 +16,7 @@ const (
 	TimeType         = `time`
 	ObjectType       = `object`
 	RawType          = `raw`
+	ArrayType        = `array`
 )
 
 func (self Type) String() string {
@@ -38,6 +39,8 @@ func ParseFieldType(in string) Type {
 		return ObjectType
 	case `raw`:
 		return RawType
+	case `array`:
+		return ArrayType
 	default:
 		return ``
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -1449,4 +1449,14 @@ func testLoadSchema(t *testing.T, db backends.Backend) {
 func testLoadFixtures(t *testing.T, db backends.Backend) {
 	assert := require.New(t)
 	assert.NoError(LoadFixtures(`./test/fixtures/`, db))
+
+	if db.Supports(backends.Constraints) {
+		assert.NotNil(db.Insert(`users`, dal.NewRecordSet(dal.NewRecord(`testXYZ`, map[string]interface{}{
+			`FirstName`:      `ShouldNot`,
+			`LastName`:       `SeeMe`,
+			`PrimaryGroupID`: `nonexistent`,
+			`PasswordHash`:   `$`,
+			`Salt`:           `abc`,
+		}))))
+	}
 }

--- a/pivot.go
+++ b/pivot.go
@@ -252,3 +252,12 @@ func LoadFixtures(fileOrDirPath string, db DB) error {
 
 	return nil
 }
+
+// A panicky version of backends.Backend.GetCollection
+func MustGetCollection(db DB, name string) *dal.Collection {
+	if collection, err := db.GetCollection(name); err == nil {
+		return collection
+	} else {
+		panic(fmt.Sprintf("Cannot get collection %q: %v", name, err))
+	}
+}

--- a/test/schema/users.json
+++ b/test/schema/users.json
@@ -8,9 +8,10 @@
         "Email",
         "PrimaryGroupID"
     ],
-    "embed": [{
-        "key":        "PrimaryGroupID",
-        "collection": "groups"
+    "constraints": [{
+        "on":         "PrimaryGroupID",
+        "collection": "groups",
+        "field":      "ID"
     }],
     "fields": [{
         "name":     "FirstName",

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package pivot
 
 const ApplicationName = `pivot`
 const ApplicationSummary = `an extensible database abstraction service`
-const ApplicationVersion = `3.0.56`
+const ApplicationVersion = `3.0.57`


### PR DESCRIPTION
- Implements Constraints, which is the ability for dal.Collection to specify relational constraints that supporting backends MAY communicate to the remote server.

- Add native support for "array" type to all backends.