### PR TITLE
Add read-only fields

### DIFF
--- a/dal/collection.go
+++ b/dal/collection.go
@@ -660,6 +660,13 @@ func (self *Collection) StructToRecord(in interface{}) (*Record, error) {
 		return nil, err
 	}
 
+	// finally, remove readonly fields that we shouldn't attempt to change
+	for _, field := range self.Fields {
+		if field.ReadOnly {
+			delete(output.Fields, field.Name)
+		}
+	}
+
 	return output, nil
 }
 

--- a/dal/field.go
+++ b/dal/field.go
@@ -101,6 +101,9 @@ type Field struct {
 	// If given a Constraint, the constraint will be added to this field's
 	// parent collection with the "On" field set to this field's name.
 	BelongsTo interface{} `json:"belongs_to,omitempty"`
+
+	// Specifies that the field may not be updated, only read.  Attempts to update the field will be silently discarded.
+	ReadOnly bool `json:"readonly,omitempty"`
 }
 
 func (self *Field) normalizeType(in interface{}) (interface{}, error) {

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package pivot
 
 const ApplicationName = `pivot`
 const ApplicationSummary = `an extensible database abstraction service`
-const ApplicationVersion = `3.3.4`
+const ApplicationVersion = `3.3.5`


### PR DESCRIPTION
- Adds a `ReadOnly` flag to `dal.Field`, which specifies that any attempt to modify such a field will discard that field.  This is especially useful for `created_at`-type fields that should be populated by a sane default and never updated again.